### PR TITLE
Remove hardcoded amd64 in build path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . $GOPATH/src/github.com/brancz/kube-rbac-proxy
 
 RUN yum install -y golang make && \
    cd $GOPATH/src/github.com/brancz/kube-rbac-proxy && \
-   make build && cp $GOPATH/src/github.com/brancz/kube-rbac-proxy/_output/linux/amd64/kube-rbac-proxy /usr/bin/ && \
+   make build && cp $GOPATH/src/github.com/brancz/kube-rbac-proxy/_output/linux/`go env GOARCH`/kube-rbac-proxy /usr/bin/ && \
    yum erase -y golang make && yum clean all
 
 LABEL io.k8s.display-name="kube-rbac-proxy" \


### PR DESCRIPTION
Replace hardcoded 'amd64' so we can build other archs.

