### PR TITLE
Dockerfile: remove unnecessary rpm dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . $GOPATH/src/github.com/brancz/kube-rbac-proxy
 RUN yum install -y golang make && \
    cd $GOPATH/src/github.com/brancz/kube-rbac-proxy && \
    make build && cp $GOPATH/src/github.com/brancz/kube-rbac-proxy/_output/linux/$(go env GOARCH)/kube-rbac-proxy /usr/bin/ && \
-   yum erase -y golang make && yum clean all
+   yum autoremove -y golang make && yum clean all
 
 LABEL io.k8s.display-name="kube-rbac-proxy" \
       io.k8s.description="This is a proxy, that can perform Kubernetes RBAC authorization." \


### PR DESCRIPTION
This will cleanup the RPMs that were installed as dependencies of golang and make.