### PR TITLE
add hardcoded authorizer to approve /metrics for metrics scraper 

### DIFF
--- a/pkg/hardcodedauthorizer/metrics.go
+++ b/pkg/hardcodedauthorizer/metrics.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2021 Frederic Branczyk All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// this is copied from library-go to avoid a hard dependency
+package hardcodedauthorizer
+
+import (
+	"context"
+
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+type metricsAuthorizer struct{}
+
+// GetUser() user.Info - checked
+// GetVerb() string - checked
+// IsReadOnly() bool - na
+// GetNamespace() string - na
+// GetResource() string - na
+// GetSubresource() string - na
+// GetName() string - na
+// GetAPIGroup() string - na
+// GetAPIVersion() string - na
+// IsResourceRequest() bool - checked
+// GetPath() string - checked
+func (metricsAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+	if a.GetUser() == nil {
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+	if a.GetUser().GetName() != "system:serviceaccount:openshift-monitoring:prometheus-k8s" {
+		return authorizer.DecisionNoOpinion, "", nil
+	}
+	if !a.IsResourceRequest() &&
+		a.GetVerb() == "get" &&
+		a.GetPath() == "/metrics" {
+		return authorizer.DecisionAllow, "requesting metrics is allowed", nil
+	}
+
+	return authorizer.DecisionNoOpinion, "", nil
+}
+
+// NewHardCodedMetricsAuthorizer returns a hardcoded authorizer for checking metrics.
+func NewHardCodedMetricsAuthorizer() *metricsAuthorizer {
+	return new(metricsAuthorizer)
+}

--- a/pkg/hardcodedauthorizer/metrics_test.go
+++ b/pkg/hardcodedauthorizer/metrics_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 Frederic Branczyk All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hardcodedauthorizer
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func TestAuthorizer(t *testing.T) {
+	tests := []struct {
+		name       string
+		authorizer authorizer.Authorizer
+
+		shouldPass      []authorizer.Attributes
+		shouldNoOpinion []authorizer.Attributes
+	}{
+		{
+			name:       "metrics",
+			authorizer: NewHardCodedMetricsAuthorizer(),
+			shouldPass: []authorizer.Attributes{
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:serviceaccount:openshift-monitoring:prometheus-k8s"}, Verb: "get", Path: "/metrics"},
+			},
+			shouldNoOpinion: []authorizer.Attributes{
+				// wrong user
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "other"}, Verb: "get", Path: "/metrics"},
+				// wrong verb
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:serviceaccount:openshift-monitoring:prometheus-k8s"}, Verb: "update", Path: "/metrics"},
+
+				// wrong path
+				authorizer.AttributesRecord{User: &user.DefaultInfo{Name: "system:serviceaccount:openshift-monitoring:prometheus-k8s"}, Verb: "get", Path: "/api"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, attr := range tt.shouldPass {
+				if decision, _, _ := tt.authorizer.Authorize(context.Background(), attr); decision != authorizer.DecisionAllow {
+					t.Errorf("incorrectly restricted %v", attr)
+				}
+			}
+
+			for _, attr := range tt.shouldNoOpinion {
+				if decision, _, _ := tt.authorizer.Authorize(context.Background(), attr); decision != authorizer.DecisionNoOpinion {
+					t.Errorf("incorrectly opinionated %v", attr)
+				}
+			}
+		})
+	}
+}

--- a/vendor/k8s.io/apiserver/pkg/authorization/union/union.go
+++ b/vendor/k8s.io/apiserver/pkg/authorization/union/union.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package union implements an authorizer that combines multiple subauthorizer.
+// The union authorizer iterates over each subauthorizer and returns the first
+// decision that is either an Allow decision or a Deny decision. If a
+// subauthorizer returns a NoOpinion, then the union authorizer moves onto the
+// next authorizer or, if the subauthorizer was the last authorizer, returns
+// NoOpinion as the aggregate decision. I.e. union authorizer creates an
+// aggregate decision and supports short-circuit allows and denies from
+// subauthorizers.
+package union
+
+import (
+	"context"
+	"strings"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+// unionAuthzHandler authorizer against a chain of authorizer.Authorizer
+type unionAuthzHandler []authorizer.Authorizer
+
+// New returns an authorizer that authorizes against a chain of authorizer.Authorizer objects
+func New(authorizationHandlers ...authorizer.Authorizer) authorizer.Authorizer {
+	return unionAuthzHandler(authorizationHandlers)
+}
+
+// Authorizes against a chain of authorizer.Authorizer objects and returns nil if successful and returns error if unsuccessful
+func (authzHandler unionAuthzHandler) Authorize(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+	var (
+		errlist    []error
+		reasonlist []string
+	)
+
+	for _, currAuthzHandler := range authzHandler {
+		decision, reason, err := currAuthzHandler.Authorize(ctx, a)
+
+		if err != nil {
+			errlist = append(errlist, err)
+		}
+		if len(reason) != 0 {
+			reasonlist = append(reasonlist, reason)
+		}
+		switch decision {
+		case authorizer.DecisionAllow, authorizer.DecisionDeny:
+			return decision, reason, err
+		case authorizer.DecisionNoOpinion:
+			// continue to the next authorizer
+		}
+	}
+
+	return authorizer.DecisionNoOpinion, strings.Join(reasonlist, "\n"), utilerrors.NewAggregate(errlist)
+}
+
+// unionAuthzRulesHandler authorizer against a chain of authorizer.RuleResolver
+type unionAuthzRulesHandler []authorizer.RuleResolver
+
+// NewRuleResolvers returns an authorizer that authorizes against a chain of authorizer.Authorizer objects
+func NewRuleResolvers(authorizationHandlers ...authorizer.RuleResolver) authorizer.RuleResolver {
+	return unionAuthzRulesHandler(authorizationHandlers)
+}
+
+// RulesFor against a chain of authorizer.RuleResolver objects and returns nil if successful and returns error if unsuccessful
+func (authzHandler unionAuthzRulesHandler) RulesFor(user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
+	var (
+		errList              []error
+		resourceRulesList    []authorizer.ResourceRuleInfo
+		nonResourceRulesList []authorizer.NonResourceRuleInfo
+	)
+	incompleteStatus := false
+
+	for _, currAuthzHandler := range authzHandler {
+		resourceRules, nonResourceRules, incomplete, err := currAuthzHandler.RulesFor(user, namespace)
+
+		if incomplete == true {
+			incompleteStatus = true
+		}
+		if err != nil {
+			errList = append(errList, err)
+		}
+		if len(resourceRules) > 0 {
+			resourceRulesList = append(resourceRulesList, resourceRules...)
+		}
+		if len(nonResourceRules) > 0 {
+			nonResourceRulesList = append(nonResourceRulesList, nonResourceRules...)
+		}
+	}
+
+	return resourceRulesList, nonResourceRulesList, incompleteStatus, utilerrors.NewAggregate(errList)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -324,6 +324,7 @@ k8s.io/apiserver/pkg/authentication/token/tokenfile
 k8s.io/apiserver/pkg/authentication/user
 k8s.io/apiserver/pkg/authorization/authorizer
 k8s.io/apiserver/pkg/authorization/authorizerfactory
+k8s.io/apiserver/pkg/authorization/union
 k8s.io/apiserver/pkg/endpoints/request
 k8s.io/apiserver/pkg/server/dynamiccertificates
 k8s.io/apiserver/pkg/server/egressselector


### PR DESCRIPTION
This is an opinionated authorizer that grants access for our metrics scraper without asking the kube-apiserver because on openshift, we know this identity should always have metrics access.