### PR TITLE
release-4.14: disable http2

### DIFF
--- a/test/e2e/http2.go
+++ b/test/e2e/http2.go
@@ -1,0 +1,52 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/brancz/kube-rbac-proxy/test/kubetest"
+	"k8s.io/client-go/kubernetes"
+)
+
+func testHTTP2(client kubernetes.Interface) kubetest.TestSuite {
+	return func(t *testing.T) {
+		command := `HTTP_VERSION=$(curl -sI --http2 --connect-timeout 5 -k --fail -w "%{http_version}\n" -o /dev/null https://kube-rbac-proxy.default.svc.cluster.local:8443/metrics); if [[ "$HTTP_VERSION" == "2" ]]; then echo "Did not expect HTTP/2. Actual protocol: $HTTP_VERSION" > /proc/self/fd/2; exit 1; fi`
+
+		kubetest.Scenario{
+			Name: "With failing HTTP2-client",
+			Description: `
+				Expecting http/2 capable client to fail to connect with http/2.
+			`,
+
+			Given: kubetest.Actions(
+				kubetest.CreatedManifests(
+					client,
+					"ignorepaths/clusterRole.yaml",
+					"ignorepaths/clusterRoleBinding.yaml",
+					"ignorepaths/deployment.yaml",
+					"ignorepaths/service.yaml",
+					"ignorepaths/serviceAccount.yaml",
+					"ignorepaths/clusterRole-client.yaml",
+					"ignorepaths/clusterRoleBinding-client.yaml",
+				),
+			),
+			When: kubetest.Actions(
+				kubetest.PodsAreReady(
+					client,
+					1,
+					"app=kube-rbac-proxy",
+				),
+				kubetest.ServiceIsReady(
+					client,
+					"kube-rbac-proxy",
+				),
+			),
+			Then: kubetest.Actions(
+				kubetest.ClientSucceeds(
+					client,
+					command,
+					nil,
+				),
+			),
+		}.Run(t)
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -59,6 +59,7 @@ func Test(t *testing.T) {
 		"IgnorePath":         testIgnorePaths(client),
 		"TLS":                testTLS(client),
 		"StaticAuthorizer":   testStaticAuthorizer(client),
+		"HTTP2":              testHTTP2(client),
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
# What

- Disable HTTP/2 by default.
- Set it up, such that we could add a flag easily.

# Why

- CVE-2023-44487.
- Hesitant to add a new flag to manage, hopefully it gets fixed by Go.