### PR TITLE
master: disable http2

### DIFF
--- a/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
+++ b/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
@@ -142,6 +142,8 @@ type completedProxyRunOptions struct {
 
 	allowPaths  []string
 	ignorePaths []string
+
+	enableHTTP2 bool
 }
 
 func (o *completedProxyRunOptions) Validate() []error {
@@ -310,6 +312,8 @@ func Run(cfg *completedProxyRunOptions) error {
 	proxy := httputil.NewSingleHostReverseProxy(cfg.upstreamURL)
 	proxy.Transport = upstreamTransport
 
+	// HTTP/2 is temporarily disabled due to CVE-2023-44487
+	// Should only affectd upstream transport.
 	if cfg.upstreamForceH2C {
 		// Force http/2 for connections to the upstream i.e. do not start with HTTP1.1 UPGRADE req to
 		// initialize http/2 session.
@@ -362,7 +366,22 @@ func Run(cfg *completedProxyRunOptions) error {
 	var gr run.Group
 	{
 		if cfg.secureListenAddress != "" {
-			srv := &http.Server{Handler: mux, TLSConfig: &tls.Config{}}
+			srv := &http.Server{
+				Handler:   mux,
+				TLSConfig: &tls.Config{},
+			}
+
+			if !cfg.enableHTTP2 {
+				// HTTP/2 is temporarily disabled due to CVE-2023-44487
+				// Programs that must disable HTTP/2 can do so by setting
+				// Transport.TLSNextProto (for clients) or Server.TLSNextProto
+				// (for servers) to a non-nil, empty map.
+				// https://pkg.go.dev/net/http
+				srv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler))
+				// For reference:
+				// https://github.com/kubernetes/kubernetes/blob/de054fbf9422d778568946de21a48c7330a6c1b7/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go#L55-L59
+				srv.TLSConfig.NextProtos = []string{"http/1.1"}
+			}
 
 			if cfg.tls.CertFile == "" && cfg.tls.KeyFile == "" {
 				klog.Info("Generating self signed cert as no cert is provided")
@@ -411,8 +430,11 @@ func Run(cfg *completedProxyRunOptions) error {
 			srv.TLSConfig.MinVersion = version
 			srv.TLSConfig.ClientAuth = tls.RequestClientCert
 
-			if err := http2.ConfigureServer(srv, nil); err != nil {
-				return fmt.Errorf("failed to configure http2 server: %w", err)
+			// HTTP/2 is temporarily disabled due to CVE-2023-44487
+			if cfg.enableHTTP2 {
+				if err := http2.ConfigureServer(srv, nil); err != nil {
+					return fmt.Errorf("failed to configure http2 server: %w", err)
+				}
 			}
 
 			gr.Add(func() error {
@@ -441,8 +463,17 @@ func Run(cfg *completedProxyRunOptions) error {
 					TLSConfig: srv.TLSConfig.Clone(),
 				}
 
-				if err := http2.ConfigureServer(proxyEndpointsSrv, nil); err != nil {
-					return fmt.Errorf("failed to configure http2 server: %w", err)
+				if !cfg.enableHTTP2 {
+					// HTTP/2 is temporarily disabled due to CVE-2023-44487
+					// Programs that must disable HTTP/2 can do so by setting
+					// Transport.TLSNextProto (for clients) or Server.TLSNextProto
+					// (for servers) to a non-nil, empty map.
+					// https://pkg.go.dev/net/http
+					proxyEndpointsSrv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler))
+				} else {
+					if err := http2.ConfigureServer(proxyEndpointsSrv, nil); err != nil {
+						return fmt.Errorf("failed to configure http2 server: %w", err)
+					}
 				}
 
 				gr.Add(func() error {
@@ -472,7 +503,13 @@ func Run(cfg *completedProxyRunOptions) error {
 	}
 	{
 		if cfg.insecureListenAddress != "" {
-			srv := &http.Server{Handler: h2c.NewHandler(mux, &http2.Server{})}
+			srv := &http.Server{}
+
+			if cfg.enableHTTP2 {
+				srv.Handler = h2c.NewHandler(mux, &http2.Server{})
+			} else {
+				srv.Handler = mux
+			}
 
 			l, err := net.Listen("tcp", cfg.insecureListenAddress)
 			if err != nil {

--- a/test/e2e/http2.go
+++ b/test/e2e/http2.go
@@ -1,0 +1,52 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/brancz/kube-rbac-proxy/test/kubetest"
+	"k8s.io/client-go/kubernetes"
+)
+
+func testHTTP2(client kubernetes.Interface) kubetest.TestSuite {
+	return func(t *testing.T) {
+		command := `HTTP_VERSION=$(curl -sI --http2 --connect-timeout 5 -k --fail -w "%{http_version}\n" -o /dev/null https://kube-rbac-proxy.default.svc.cluster.local:8443/metrics); if [[ "$HTTP_VERSION" == "2" ]]; then echo "Did not expect HTTP/2. Actual protocol: $HTTP_VERSION" > /proc/self/fd/2; exit 1; fi`
+
+		kubetest.Scenario{
+			Name: "With failing HTTP2-client",
+			Description: `
+				Expecting http/2 capable client to fail to connect with http/2.
+			`,
+
+			Given: kubetest.Actions(
+				kubetest.CreatedManifests(
+					client,
+					"ignorepaths/clusterRole.yaml",
+					"ignorepaths/clusterRoleBinding.yaml",
+					"ignorepaths/deployment.yaml",
+					"ignorepaths/service.yaml",
+					"ignorepaths/serviceAccount.yaml",
+					"ignorepaths/clusterRole-client.yaml",
+					"ignorepaths/clusterRoleBinding-client.yaml",
+				),
+			),
+			When: kubetest.Actions(
+				kubetest.PodsAreReady(
+					client,
+					1,
+					"app=kube-rbac-proxy",
+				),
+				kubetest.ServiceIsReady(
+					client,
+					"kube-rbac-proxy",
+				),
+			),
+			Then: kubetest.Actions(
+				kubetest.ClientSucceeds(
+					client,
+					command,
+					nil,
+				),
+			),
+		}.Run(t)
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -59,6 +59,7 @@ func Test(t *testing.T) {
 		"IgnorePath":         testIgnorePaths(client),
 		"TLS":                testTLS(client),
 		"StaticAuthorizer":   testStaticAuthorizer(client),
+		"HTTP2":              testHTTP2(client),
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
# What

- Disable HTTP/2 by default.
- Set it up, such that we could add a flag easily.

# Why

- CVE-2023-44487.
- Hesitant to add a new flag to manage, hopefully it gets fixed by Go.