### PR TITLE
OCPBUGS-83863: Strip debug symbols from Go binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,16 @@ all: check-license build generate test
 GO111MODULE=on
 export GO111MODULE
 
+# Set DBG=1 to build without stripping debug symbols. Default produces a
+# stripped binary.
+DBG ?=
+
+ifeq ($(DBG),1)
+GOLDFLAGS ?=
+else
+GOLDFLAGS ?= -s -w
+endif
+
 PROGRAM_NAME?=kube-rbac-proxy
 GITHUB_URL=github.com/brancz/kube-rbac-proxy
 GOOS?=$(shell uname -s | tr A-Z a-z)
@@ -43,7 +53,7 @@ $(OUT_DIR)/$(PROGRAM_NAME)-%:
 	GOARCH=$(word 2,$(subst -, ,$(*:.exe=))) \
 	GOOS=$(word 1,$(subst -, ,$(*:.exe=))) \
 	CGO_ENABLED=0 \
-	go build --installsuffix cgo -ldflags="-X k8s.io/component-base/version.gitVersion=$(VERSION_SEMVER) -X k8s.io/component-base/version.gitCommit=$(shell git rev-parse HEAD) -X k8s.io/component-base/version/verflag.programName=$(PROGRAM_NAME)" -o $(OUT_DIR)/$(PROGRAM_NAME)-$* $(GITHUB_URL)/cmd/kube-rbac-proxy
+	go build --installsuffix cgo -ldflags="$(GOLDFLAGS) -X k8s.io/component-base/version.gitVersion=$(VERSION_SEMVER) -X k8s.io/component-base/version.gitCommit=$(shell git rev-parse HEAD) -X k8s.io/component-base/version/verflag.programName=$(PROGRAM_NAME)" -o $(OUT_DIR)/$(PROGRAM_NAME)-$* $(GITHUB_URL)/cmd/kube-rbac-proxy
 
 clean:
 	-rm -r $(OUT_DIR)


### PR DESCRIPTION
Upstream PR https://github.com/kube-rbac-proxy/kube-rbac-proxy/pull/447

Reduces the binary size by approximately 32% when built with go1.26.5.

Unstripped (DBG=1):
-rwxr-xr-x. 1 sdodson sdodson 77136200 Jul 15 13:19 kube-rbac-proxy-linux-amd64
Stripped:
-rwxr-xr-x. 1 sdodson sdodson 52355234 Jul 15 13:18 kube-rbac-proxy-linux-amd64

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized binary builds to reduce file sizes by stripping debug information from compiled executables by default.
  * Added a build option to disable stripping and keep debug symbols when needed (using `DBG=1`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->