### PR TITLE
WIP: OCPBUGS-63708: demote TCP-reset TLS handshake errors to verbose logging

### DIFF
--- a/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
+++ b/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -327,6 +328,7 @@ func Run(cfg *completedProxyRunOptions) error {
 			srv := &http.Server{
 				Handler:   mux,
 				TLSConfig: &tls.Config{},
+				ErrorLog:  log.New(&tlsHandshakeErrorFilter{}, "", 0),
 			}
 
 			if cfg.tls.CertFile == "" && cfg.tls.KeyFile == "" {
@@ -417,6 +419,7 @@ func Run(cfg *completedProxyRunOptions) error {
 				proxyEndpointsSrv := &http.Server{
 					Handler:   proxyEndpointsMux,
 					TLSConfig: srv.TLSConfig.Clone(),
+					ErrorLog:  log.New(&tlsHandshakeErrorFilter{}, "", 0),
 				}
 
 				if cfg.http2Disable {

--- a/cmd/kube-rbac-proxy/app/tls_error_filter.go
+++ b/cmd/kube-rbac-proxy/app/tls_error_filter.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 the kube-rbac-proxy maintainers. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+// tlsHandshakeErrorFilter is an io.Writer intended for use as http.Server.ErrorLog.
+// It demotes TLS handshake errors caused by abruptly closed connections (e.g. TCP
+// health checks from load balancers) to verbose logging, while preserving all other
+// TLS errors (expired certificates, unsupported protocols, etc.) at the default log level.
+type tlsHandshakeErrorFilter struct{}
+
+// Write implements io.Writer.
+func (f *tlsHandshakeErrorFilter) Write(p []byte) (n int, err error) {
+	msg := string(p)
+	if isTCPResetHandshakeError(msg) {
+		klog.V(4).Info(msg)
+		return len(p), nil
+	}
+	klog.InfoDepth(3, msg)
+	return len(p), nil
+}
+
+// isTCPResetHandshakeError reports whether msg is a TLS handshake error caused
+// by the remote side closing the connection before the handshake completed.
+// This is the signature of TCP-level health checks performed by load balancers
+// that open a connection to verify liveness and then immediately close it with
+// a TCP RST, producing harmless log noise with no functional impact.
+// All other TLS handshake errors (expired certificates, unknown authorities,
+// unsupported protocol versions, etc.) return false and are logged normally.
+func isTCPResetHandshakeError(msg string) bool {
+	return strings.Contains(msg, "http: TLS handshake error") &&
+		strings.Contains(msg, "connection reset by peer")
+}

--- a/cmd/kube-rbac-proxy/app/tls_error_filter_test.go
+++ b/cmd/kube-rbac-proxy/app/tls_error_filter_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 the kube-rbac-proxy maintainers. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"testing"
+)
+
+func Test_isTCPResetHandshakeError(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			// Canonical message produced by a load balancer TCP health check:
+			// the load balancer opens a TCP connection to verify liveness and
+			// then closes it with a TCP RST before the TLS handshake completes.
+			name:  "TCP reset during TLS handshake is demoted (load balancer health check)",
+			input: "http: TLS handshake error from 10.131.0.8:55126: write tcp 10.129.2.17:9091->10.131.0.8:55126: write: connection reset by peer\n",
+			want:  true,
+		},
+		{
+			name:  "expired certificate TLS error is not demoted",
+			input: "http: TLS handshake error from 10.0.0.1:1234: x509: certificate has expired or is not yet valid\n",
+			want:  false,
+		},
+		{
+			name:  "unknown certificate authority TLS error is not demoted",
+			input: "http: TLS handshake error from 10.0.0.1:1234: x509: certificate signed by unknown authority\n",
+			want:  false,
+		},
+		{
+			name:  "unsupported TLS version error is not demoted",
+			input: "http: TLS handshake error from 10.0.0.1:1234: tls: no supported versions satisfy MinVersion and MaxVersion\n",
+			want:  false,
+		},
+		{
+			name:  "unrelated server message is not demoted",
+			input: "server is shutting down\n",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTCPResetHandshakeError(tt.input); got != tt.want {
+				t.Errorf("isTCPResetHandshakeError(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_tlsHandshakeErrorFilter_Write(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "non-matching message is passed through",
+			input: "any message\n",
+		},
+		{
+			name:  "matching TCP-reset message is handled without error",
+			input: "http: TLS handshake error from 10.131.0.8:55126: write tcp 10.129.2.17:9091->10.131.0.8:55126: write: connection reset by peer\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &tlsHandshakeErrorFilter{}
+			n, err := f.Write([]byte(tt.input))
+			if err != nil {
+				t.Errorf("Write() returned unexpected error: %v", err)
+			}
+			if n != len(tt.input) {
+				t.Errorf("Write() returned n=%d, want %d", n, len(tt.input))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Load balancers such as HAProxy perform periodic TCP-level health checks by opening a connection and immediately closing it with a TCP RST before the TLS handshake completes. This causes `http.Server` to log a continuous stream of
`http: TLS handshake error ... connection reset by peer` messages at the default log level, producing significant noise with no functional impact.

- Add `tlsHandshakeErrorFilter` as `http.Server.ErrorLog` for both TLS listeners
- Messages matching both `http: TLS handshake error` and `connection reset by peer`
  are demoted to `V(4)` and remain accessible under `-v=4`
- All other TLS handshake errors (expired certificates, unknown authorities,
  unsupported protocol versions) are unaffected and logged at the default level

> **Note:** This is a downstream WIP PR to validate the fix via OCP CI before upstreaming to [kube-rbac-proxy/kube-rbac-proxy](https://github.com/kube-rbac-proxy/kube-rbac-proxy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy TLS handshake error logs from routine connection drops, making server logs cleaner.
  * Kept genuine TLS handshake issues visible at the normal error level.
* **Tests**
  * Added coverage for error filtering behavior and handshake error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->