### PR TITLE
NO-JIRA: update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,24 +1,9 @@
 reviewers:
-- stlaz
-- s-urbaniak
-- deads2k
 - ibihim
 - liouk
+- control-plane-approvers
 
 approvers:
-- stlaz
-- s-urbaniak
-- deads2k
 - ibihim
-
-emeritus_approvers:
-- sttts
-- elad661
-- ironcladlou
-- squat
-- brancz
-- pgier
-- LiliC
-- paulfantom
-- simonpasquier
-- dgrisonnet
+- liouk
+- control-plane-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,15 @@
+aliases:
+  control-plane-approvers:
+    - ardaguclu
+    - atiratree
+    - benluddy
+    - bertinatto
+    - everettraven
+    - flavianmissi
+    - gangwgr
+    - ingvagabund
+    - kaleemsiddiqu
+    - p0lyn0mial
+    - ricardomaraschini
+    - tjungblu
+    - xueqzhan


### PR DESCRIPTION
Add control plane approvers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review and approval assignments.
  * Added the control-plane approvers group to ownership settings.
  * Removed outdated individual entries and the retired emeritus approvers section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->